### PR TITLE
ledger: don't sample own block

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -936,15 +936,6 @@ func (l *Ledger) query() {
 		votes = append(votes, &response.vote)
 	}
 
-	// Include our own vote as well.
-
-	var preferred *Block = nil
-	if vote, ok := l.finalizer.Preferred().(*finalizationVote); ok && vote != nil {
-		preferred = vote.block
-	}
-
-	votes = append(votes, &finalizationVote{voter: l.client.ID(), block: preferred})
-
 	l.filterInvalidVotes(current, votes)
 	l.finalizer.Tick(calculateTallies(l.accounts, votes))
 }


### PR DESCRIPTION
### Description

The code changes in this pull request involve removing the inclusion of the node's own vote from the list of votes considered in the ledger. Here are the summarized changes:

- Removal of the code that includes the node's own vote in the list of votes.
- The section of code that assigns the preferred block based on the node's own vote is eliminated.
- The appending of the node's own finalization vote to the list of votes has been removed.

These changes likely aim to adjust the voting mechanism to exclude self-voting from the ledger calculations or to streamline the code by removing unnecessary logic around the node's own vote.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the addition of the ledger's own vote in the block sampling process within the `query` function of `ledger.go`.

### Why are these changes being made?

The change is made to prevent the ledger from sampling its own block, which could skew vote results and lead to unintended finalization outcomes. Removing the ledger's attempt to vote for its own block improves the integrity and fairness of the voting process by ensuring all votes are externally derived rather than self-referential.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->